### PR TITLE
icons showing up as wrong size in upgrade planner

### DIFF
--- a/prototypes/entity/active-provider.lua
+++ b/prototypes/entity/active-provider.lua
@@ -9,6 +9,9 @@ end
 
 local chest = table.deepcopy(vanilla_entity)
 chest.name = "titanium-logistic-chest-active-provider"
+chest.icon = "__FactorioExtended-Plus-Storage__/graphics/icons/titanium-logistic-chest-active-provider.png"
+chest.icon_mipmaps = 4
+chest.icon_size = 64
 chest.minable.result = chest.name
 chest.next_upgrade = nil
 chest.max_health = 500

--- a/prototypes/entity/buffer-chest.lua
+++ b/prototypes/entity/buffer-chest.lua
@@ -9,6 +9,9 @@ end
 
 local chest = table.deepcopy(vanilla_entity)
 chest.name = "titanium-logistic-chest-buffer"
+chest.icon = "__FactorioExtended-Plus-Storage__/graphics/icons/titanium-logistic-chest-buffer.png"
+chest.icon_mipmaps = 4
+chest.icon_size = 64
 chest.minable.result = chest.name
 chest.next_upgrade = nil
 chest.max_health = 500

--- a/prototypes/entity/passive-provider.lua
+++ b/prototypes/entity/passive-provider.lua
@@ -9,6 +9,9 @@ end
 
 local chest = table.deepcopy(vanilla_entity)
 chest.name = "titanium-logistic-chest-passive-provider"
+chest.icon = "__FactorioExtended-Plus-Storage__/graphics/icons/titanium-logistic-chest-passive-provider.png"
+chest.icon_mipmaps = 4
+chest.icon_size = 64
 chest.minable.result = chest.name
 chest.next_upgrade = nil
 chest.max_health = 500

--- a/prototypes/entity/requester-chest.lua
+++ b/prototypes/entity/requester-chest.lua
@@ -9,6 +9,9 @@ end
 
 local chest = table.deepcopy(vanilla_entity)
 chest.name = "titanium-logistic-chest-requester"
+chest.icon = "__FactorioExtended-Plus-Storage__/graphics/icons/titanium-logistic-chest-requester.png"
+chest.icon_mipmaps = 4
+chest.icon_size = 64
 chest.minable.result = chest.name
 chest.next_upgrade = nil
 chest.max_health = 500

--- a/prototypes/entity/storage-chest.lua
+++ b/prototypes/entity/storage-chest.lua
@@ -9,6 +9,9 @@ end
 
 local chest = table.deepcopy(vanilla_entity)
 chest.name = "titanium-logistic-chest-storage"
+chest.icon = "__FactorioExtended-Plus-Storage__/graphics/icons/titanium-logistic-chest-storage.png"
+chest.icon_mipmaps = 4
+chest.icon_size = 64
 chest.minable.result = chest.name
 chest.next_upgrade = nil
 chest.max_health = 500

--- a/prototypes/entity/titanium-chest.lua
+++ b/prototypes/entity/titanium-chest.lua
@@ -9,6 +9,9 @@ end
 
 local chest = table.deepcopy(vanilla_entity)
 chest.name = "titanium-chest"
+chest.icon = "__FactorioExtended-Plus-Storage__/graphics/icons/titanium-chest.png"
+chest.icon_mipmaps = 4
+chest.icon_size = 64
 chest.inventory_size = 96
 chest.minable.result = chest.name
 chest.next_upgrade = nil


### PR DESCRIPTION
When using an upgrade planner,  the entity icons are used.  These have been changed to use the same 64x64 icons that the items use.